### PR TITLE
chore(pylint.yml): update Python versions in matrix to include 3.11

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
The Python versions in the matrix for the pylint workflow have been updated to include version 3.11 and drop version 3.8. This ensures that the codebase is tested against the latest Python version and helps identify any potential compatibility issues.